### PR TITLE
[codex] DocC 배포 브랜치를 gh-pages로 변경

### DIFF
--- a/.github/workflows/deploy-docc.yml
+++ b/.github/workflows/deploy-docc.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           deploy_key: ${{ secrets.DOCS_DEPLOY_KEY }}
           external_repository: swift-man/docs
-          publish_branch: main
+          publish_branch: gh-pages
           publish_dir: ./docs
           destination_dir: KoreanLunarSolarConverter
           full_commit_message: Deploy KoreanLunarSolarConverter DocC from ${{ github.repository }}@${{ github.sha }}


### PR DESCRIPTION
## 변경 사항

- `swift-man/docs`의 GitHub Pages source에 맞춰 DocC 배포 대상 브랜치를 `main`에서 `gh-pages`로 변경했습니다.
- 기존 `destination_dir: KoreanLunarSolarConverter` 설정은 유지했습니다.

## 이유

`swift-man/docs`는 여러 저장소의 문서를 같은 Pages 브랜치에 폴더별로 배포하는 구조입니다. 현재 Pages source가 `gh-pages`이므로, `KoreanLunarSolarConverter/` 산출물도 `gh-pages`에 배포되어야 실제 `docs.gorani.me`에서 서빙됩니다.

`peaceiris/actions-gh-pages`는 `destination_dir`가 있을 때 해당 디렉터리만 교체하므로, `LaunchingService/` 같은 다른 저장소의 배포 산출물에는 영향을 주지 않습니다. `keep_files: true`는 stale DocC 파일을 남길 수 있어 사용하지 않았습니다.

## 검증

- `./GeneratingDocumentationSite`
- 생성된 36개 HTML에서 루트 `/js`, `/css`, `/favicon`, `baseUrl = "/"` 잔여 참조 없음 확인