### PR TITLE
fix. DocC 배포 브랜치를 main으로 변경

### DIFF
--- a/.github/workflows/deploy-docc.yml
+++ b/.github/workflows/deploy-docc.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           deploy_key: ${{ secrets.DOCS_DEPLOY_KEY }}
           external_repository: swift-man/docs
-          publish_branch: gh-pages
+          publish_branch: main
           publish_dir: ./docs
           destination_dir: KoreanLunarSolarConverter
           full_commit_message: Deploy KoreanLunarSolarConverter DocC from ${{ github.repository }}@${{ github.sha }}


### PR DESCRIPTION
## 작업 내용
- `swift-man/docs` GitHub Pages 소스가 `main` 브랜치인 상태에 맞춰 DocC 배포 워크플로의 `publish_branch`를 `main`으로 변경했습니다.
- `destination_dir: KoreanLunarSolarConverter`는 유지하여 같은 docs 저장소의 `LaunchingService`, `LaunchingView` 등 다른 문서 디렉터리에 영향을 주지 않도록 했습니다.

## 확인
- `./GeneratingDocumentationSite` 실행 성공
- `gh api repos/swift-man/docs/pages`로 Pages 소스가 `main` 브랜치임을 확인
- `swift-man/docs` `main` 브랜치에 `KoreanLunarSolarConverter`, `LaunchingService`, `LaunchingView` 디렉터리가 함께 존재함을 확인했습니다.