### PR TITLE
chore. Swift tools version을 6.0으로 변경

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
## 작업 내용
- `Package.swift`의 `swift-tools-version` 선언을 `5.9`에서 `6.0`으로 변경했습니다.
- 패키지 소스나 공개 API 변경 없이 Swift 6 기반 매니페스트로만 조정했습니다.

## 확인
- `swift --version`: Apple Swift 6.3.2
- `swift build -v` 성공
- `swift test -v` 성공, 45개 테스트 통과
- `./GeneratingDocumentationSite` 성공